### PR TITLE
Latched publisher

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -210,7 +210,7 @@ public:
    * \param wait_for_subscriber - whether a sleep for loop should be used to check for connectivity to an external node
    *                              before proceeding
    */
-  void loadMarkerPub(bool wait_for_subscriber = false);
+  void loadMarkerPub(bool wait_for_subscriber = false, bool latched=false);
 
   /**
    * \brief Wait until at least one subscriber connects to a publisher

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -272,7 +272,7 @@ void RvizVisualTools::loadMarkerPub(bool wait_for_subscriber)
     return;
 
   // Rviz marker publisher
-  pub_rviz_markers_ = nh_.advertise<visualization_msgs::MarkerArray>(marker_topic_, 10);
+  pub_rviz_markers_ = nh_.advertise<visualization_msgs::MarkerArray>(marker_topic_, 10, true);
   ROS_DEBUG_STREAM_NAMED(name_, "Publishing Rviz markers on topic " << pub_rviz_markers_.getTopic());
 
   if (wait_for_subscriber)

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -266,13 +266,13 @@ bool RvizVisualTools::loadRvizMarkers()
   return true;
 }
 
-void RvizVisualTools::loadMarkerPub(bool wait_for_subscriber)
+void RvizVisualTools::loadMarkerPub(bool wait_for_subscriber, bool latched)
 {
   if (pub_rviz_markers_)
     return;
 
   // Rviz marker publisher
-  pub_rviz_markers_ = nh_.advertise<visualization_msgs::MarkerArray>(marker_topic_, 10, true);
+  pub_rviz_markers_ = nh_.advertise<visualization_msgs::MarkerArray>(marker_topic_, 10, latched);
   ROS_DEBUG_STREAM_NAMED(name_, "Publishing Rviz markers on topic " << pub_rviz_markers_.getTopic());
 
   if (wait_for_subscriber)


### PR DESCRIPTION
In our application, we have separate nodes to launch rviz and markers_viewer using this package. The two packages start at different times. When rviz is launched after the markers are done publishing, markers are missed by the rviz to be displayed.

Making the publisher latched will solve this problem of not having the subscriber(rviz) at the time of publishing.