### PR TITLE
Trigger loadMarkerPub on init

### DIFF
--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -64,6 +64,7 @@ void RvizVisualTools::initialize()
   global_scale_ = 1.0;
   // Cache the reusable markers
   loadRvizMarkers();
+  loadMarkerPub();
 }
 
 bool RvizVisualTools::deleteAllMarkers()


### PR DESCRIPTION
`loadMarkerPub` is called when `publishMarkers` is called.
However if we want to make sure that the publisher has a subscriber before publishing; we need to call `waitForMarkerPub`.

But if `waitForMarkerPub` is called before any `publishMarkers`, the publisher has not been created and thus has an empty topic name, which leads to an infinite loop.

Initializing the marker in the constructor looks like the right thing to do.