### PR TITLE
Add new function to display arrow

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -551,6 +551,18 @@ public:
                     double length = 0.0, std::size_t id = 0);
 
   /**
+     * \brief Display an arrow from an origin point toward an orientation
+     * \param origin - the origin point to publish the marker with respect to the base frame
+     * \param end_point - the end point of the arrow to publish
+     * \param color - an enum pre-defined name of a color
+     * \param scale - an enum pre-defined name of a size
+     * \param length - how long the arrow tail should be. if zero, will auto set with scale
+     * \return true on success
+     */
+  bool publishArrow(const Eigen::Vector3d origin, const Eigen::Vector3d end_point, colors color = BLUE,
+                    scales scale = MEDIUM, std::size_t id = 0);
+
+  /**
    * \brief Display a rectangular cuboid
    * \param point1 - x,y,z top corner location of box
    * \param point2 - x,y,z bottom opposite corner location of box

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -1331,6 +1331,44 @@ bool RvizVisualTools::publishArrow(const geometry_msgs::PoseStamped &pose, color
   return true;
 }
 
+bool RvizVisualTools::publishArrow(const Eigen::Vector3d origin, const Eigen::Vector3d end_point, colors color,
+                                   scales scale, std::size_t id)
+{
+  // Set the frame ID and timestamp.
+  arrow_marker_.header.stamp = ros::Time::now();
+  arrow_marker_.header.frame_id = base_frame_;
+
+  if (id == 0)
+    arrow_marker_.id++;
+  else
+    arrow_marker_.id = id;
+
+  geometry_msgs::Point start;
+  start.x = origin[0];
+  start.y = origin[1];
+  start.z = origin[2];
+
+  geometry_msgs::Point end;
+  end.x = end_point[0];
+  end.y = end_point[1];
+  end.z = end_point[2];
+
+  arrow_marker_.points.push_back(start);
+  arrow_marker_.points.push_back(end);
+
+  arrow_marker_.color = getColor(color);
+  geometry_msgs::Vector3 scale_values = getScale(scale);
+  arrow_marker_.scale.x = scale_values.x;
+  arrow_marker_.scale.y = 2*scale_values.y;
+  arrow_marker_.scale.z = (1/10) * (end_point - origin).norm();
+
+  // Helper for publishing rviz markers
+  publishMarker(arrow_marker_);
+
+  arrow_marker_.header.frame_id = base_frame_;  // restore default frame
+  return true;
+}
+
 bool RvizVisualTools::publishAxisLabeled(const Eigen::Affine3d &pose, const std::string &label, scales scale,
                                          colors color)
 {


### PR DESCRIPTION
@VictorLamoine 
We added this function for making the publish of arrow easier. You just have to have to give as parameters the start point and the end point of your arrow. I think it is more convenient than using a affine3d or geometry_msgs Pose when you just want to display an arrow. What do you think about that ? 