### PR TITLE
Catkin depend on eigen and tf conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,12 @@ catkin_package(
   LIBRARIES
     ${PROJECT_NAME}
   CATKIN_DEPENDS
+    eigen_conversions
     geometry_msgs
     visualization_msgs
     graph_msgs
     std_msgs
+    tf_conversions
     trajectory_msgs
   INCLUDE_DIRS include
 )

--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,9 @@
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
 
+  <run_depend>eigen_conversions</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>tf_conversions</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>graph_msgs</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
We need `eigen_conversions` and `tf_conversions` in `CATKIN_DEPENDS`, so the executables (or libraries) linking against this library build without adding those dependencies on them, since it's actually a (transitive) dependency of `rviz_visual_tools`.

Error:
``` bash
/usr/bin/ld: warning: libeigen_conversions.so, needed by /opt/ros/indigo/lib/librviz_visual_tools.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libtf_conversions.so, needed by /opt/ros/indigo/lib/librviz_visual_tools.so, not found (try using -rpath or -rpath-link)
/opt/ros/indigo/lib/librviz_visual_tools.so: undefined reference to `tf::pointEigenToMsg(Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, geometry_msgs::Point_<std::allocator<void> >&)'
/opt/ros/indigo/lib/librviz_visual_tools.so: undefined reference to `tf::poseMsgToEigen(geometry_msgs::Pose_<std::allocator<void> > const&, Eigen::Transform<double, 3, 2, 0>&)'
/opt/ros/indigo/lib/librviz_visual_tools.so: undefined reference to `tf::vectorEigenToTF(Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, tf::Vector3&)'
/opt/ros/indigo/lib/librviz_visual_tools.so: undefined reference to `tf::quaternionTFToEigen(tf::Quaternion const&, Eigen::Quaternion<double, 0>&)'
/opt/ros/indigo/lib/librviz_visual_tools.so: undefined reference to `tf::transformEigenToMsg(Eigen::Transform<double, 3, 2, 0> const&, geometry_msgs::Transform_<std::allocator<void> >&)'
/opt/ros/indigo/lib/librviz_visual_tools.so: undefined reference to `tf::poseEigenToMsg(Eigen::Transform<double, 3, 2, 0> const&, geometry_msgs::Pose_<std::allocator<void> >&)'
collect2: error: ld returned 1 exit status
```