### PR TITLE
Allow publishPath with std_msgs::ColorRGBA

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -640,8 +640,8 @@ a   *        Warning: when using this in a loop be sure to call trigger() at end
                         const std::string &ns = "Path");
 
   /**
-   * \brief Display a marker of a series of connected lines
-   * \param path - a series of points to connect with lines
+   * \brief Display a marker of a series of connected cylinders
+   * \param path - a series of points to connect with cylinders
    * \param color - an enum pre-defined name of a color
    * \param scale - an enum pre-defined name of a size
    * \param ns - namespace of marker
@@ -663,16 +663,19 @@ a   *        Warning: when using this in a loop be sure to call trigger() at end
                    const std::string &ns = "Path");
 
   /**
-   * \brief Display a marker of a series of connected colored lines
-   * \param path - a series of points to connect with lines
+   * \brief Display a marker of a series of connected colored cylinders
+   * \param path - a series of points to connect with cylinders
    * \param colors - a series of colors
-   * \param radius - the thickness of the line
+   * \param radius - the radius of the cylinders
    * \param ns - namespace of marker
    * \return true on success
    * \note path and colors vectors must be the same size
    */
   bool publishPath(const EigenSTL::vector_Vector3d &path, const std::vector<colors> &colors, double radius = 0.01,
                    const std::string &ns = "Path");
+
+  bool publishPath(const EigenSTL::vector_Vector3d &path, const std::vector<std_msgs::ColorRGBA> &colors,
+                   double radius, const std::string &ns = "Path");
 
   /**
    * \brief Display a marker of a polygon

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -1911,6 +1911,29 @@ bool RvizVisualTools::publishPath(const EigenSTL::vector_Vector3d &path, const s
   return true;
 }
 
+bool RvizVisualTools::publishPath(const EigenSTL::vector_Vector3d &path, const std::vector<std_msgs::ColorRGBA> &colors,
+                                  double radius, const std::string &ns)
+{
+  if (path.size() < 2)
+  {
+    ROS_WARN_STREAM_NAMED(name_, "Skipping path because " << path.size() << " points passed in.");
+    return true;
+  }
+
+  if (path.size() != colors.size())
+  {
+    ROS_ERROR_STREAM_NAMED(name_, "Skipping path because " << path.size() << " different from " << colors.size()
+                                                           << ".");
+    return false;
+  }
+
+  // Create the cylinders
+  for (std::size_t i = 1; i < path.size(); ++i)
+    publishCylinder(path[i - 1], path[i], colors[i], radius, ns);
+
+  return true;
+}
+
 bool RvizVisualTools::publishPolygon(const geometry_msgs::Polygon &polygon, colors color, scales scale,
                                      const std::string &ns)
 {


### PR DESCRIPTION
It's me again :)

I have changed the function documentation, I think it was hard to make the difference between `publishLines` and `publishPath`, this description should be more explicit.

I added a new variant of `publishPath` that allows publishing cylinders (as a path) with custom colors.
It was possible with `publishLines` and I think it's useful with `publishPath` too!

![publishlines](https://user-images.githubusercontent.com/5566160/26966184-5666ebe6-4cf9-11e7-9129-a4e8b5f68b53.png)


![publishpath](https://user-images.githubusercontent.com/5566160/26966185-5b74fd3a-4cf9-11e7-8dbf-05624612c51f.png)

