### PR TITLE
3.4.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rviz_visual_tools</name>
-  <version>3.4.1</version>
+  <version>3.4.2</version>
   <description>Utility functions for displaying and debugging data in Rviz via published markers</description>
 
   <maintainer email="davetcoleman@gmail.com">Dave Coleman</maintainer>


### PR DESCRIPTION
Can we bump the package version to `3.4.2` as `3.4.1` is already released?
Otherwise I have no way of requiring the latest version in my projects using RVT!