### PR TITLE
fix for ambiguous function call to publishAxis

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -758,7 +758,7 @@ a   *        Warning: when using this in a loop be sure to call trigger() at end
    */
   bool publishAxis(const geometry_msgs::Pose& pose, scales scale = MEDIUM, const std::string& ns = "Axis");
   bool publishAxis(const Eigen::Affine3d& pose, scales scale = MEDIUM, const std::string& ns = "Axis");
-  bool publishAxis(const geometry_msgs::Pose& pose, double length = 0.1, double radius = 0.01,
+  bool publishAxis(const geometry_msgs::Pose& pose, double length, double radius = 0.01,
                    const std::string& ns = "Axis");
   bool publishAxis(const Eigen::Affine3d& pose, double length, double radius = 0.01, const std::string& ns = "Axis");
 


### PR DESCRIPTION
Ambiguous function call for. Removed `length` default value so the `geometry_msgs` call matched the `eigen` call.